### PR TITLE
Bugfix sync status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# local testing
+.vscode
+*.sh
+
+wespoulsen-artifacts

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -144,6 +144,9 @@ def main():
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
         if full_pickle_path:
             connector_id, execution_time = load_pickle_variables(full_pickle_path)
+    ## TODO Remove below
+    print(f'Connector ID is {connector_id}')
+    print(f'Execution time is {execution_time}')
     # if args.connector_id:
     #     connector_id = args.connector_id
     # elif shipyard_upstream_vessels:

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -127,7 +127,6 @@ def main():
 
     connector_id = None
     execution_time = None
-    ## check to see if the connector id is available in upstream vessels
     if shipyard_upstream_vessels:
         shipyard_upstream_vessels = shipyard_upstream_vessels.split(',')
         for vessel_id in shipyard_upstream_vessels:
@@ -144,28 +143,6 @@ def main():
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
         if full_pickle_path:
             connector_id, execution_time = load_pickle_variables(full_pickle_path)
-    ## TODO Remove below
-    print(f'Connector ID is {connector_id}')
-    print(f'Execution time is {execution_time}')
-    # if args.connector_id:
-    #     connector_id = args.connector_id
-    # elif shipyard_upstream_vessels:
-    #     shipyard_upstream_vessels = shipyard_upstream_vessels.split(',')
-    #     for vessel_id in shipyard_upstream_vessels:
-    #         full_pickle_path = working_pickle_file(
-    #             pickle_folder_name,
-    #             f'{vessel_id}_force_sync.pickle')
-    #         if full_pickle_path:
-    #             connector_id, execution_time = load_pickle_variables(
-    #                 full_pickle_path)
-
-    # if not connector_id and not execution_time:
-    #     full_pickle_path = working_pickle_file(
-    #         pickle_folder_name,
-    #         f'force_sync.pickle')
-    #     if full_pickle_path:
-    #         connector_id, execution_time = load_pickle_variables(
-    #             full_pickle_path)
 
     connector_details_response = get_connector_details(
         connector_id,

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -145,6 +145,7 @@ def main():
                         execution_time = temp_execution_time
                 else:
                     connector_id = temp_con_id 
+                    execution_time = temp_execution_time
     ## if just the connector is provided
     elif connector_id:
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -1,3 +1,4 @@
+from genericpath import isfile
 from httprequest_blueprints import execute_request
 import argparse
 import os
@@ -144,12 +145,13 @@ def main():
     ## if just the connector is provided
     elif connector_id:
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
-        temp_con_id, temp_execution_time = load_pickle_variables(full_pickle_path)
-        if temp_con_id == connector_id:
-            execution_time = temp_execution_time
+        if os.path.isfile(full_pickle_path):
+            temp_con_id, temp_execution_time = load_pickle_variables(full_pickle_path)
+            if temp_con_id == connector_id:
+                execution_time = temp_execution_time
 
     ## if the connetor id is not provided
-    else:
+    elif not connector_id and not execution_time:
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
         if full_pickle_path:
             connector_id, execution_time = load_pickle_variables(full_pickle_path)

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -141,35 +141,18 @@ def main():
                 temp_con_id, temp_execution_time = load_pickle_variables(full_pickle_path)
                 if temp_con_id == connector_id:
                     execution_time = temp_execution_time
-                # else:
-                #     connector_id, execution_time = load_pickle_variables(
-                #         full_pickle_path)
-    # if args.connector_id:
-    #     connector_id = args.connector_id
+    ## if just the connector is provided
     elif connector_id:
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
         temp_con_id, temp_execution_time = load_pickle_variables(full_pickle_path)
         if temp_con_id == connector_id:
             execution_time = temp_execution_time
 
+    ## if the connetor id is not provided
     else:
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
         if full_pickle_path:
             connector_id, execution_time = load_pickle_variables(full_pickle_path)
-
-
-    # if shipyard_upstream_vessels:
-    #     shipyard_upstream_vessels = shipyard_upstream_vessels.split(',')
-    #     for vessel_id in shipyard_upstream_vessels:
-    #         full_pickle_path = working_pickle_file(
-    #             pickle_folder_name,
-    #             f'{vessel_id}_force_sync.pickle')
-    #         if full_pickle_path:
-    #             connector_id, execution_time = load_pickle_variables(
-    #                 full_pickle_path)
-    # elif args.connector_id:
-    #     connector_id = args.connector_id
-    
 
     connector_details_response = get_connector_details(
         connector_id,

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -125,24 +125,51 @@ def main():
         f'{base_folder_name}/variables')
     execute_request.create_folder_if_dne(pickle_folder_name)
 
-    connector_id = None
+    # connector_id = None
+    connector_id = args.connector_id
     execution_time = None
-    if shipyard_upstream_vessels:
+    ## if there are upstream vessels
+    ## if the connector id is not provided then we don't care about the other 
+    if shipyard_upstream_vessels and connector_id:
         shipyard_upstream_vessels = shipyard_upstream_vessels.split(',')
         for vessel_id in shipyard_upstream_vessels:
             full_pickle_path = working_pickle_file(
                 pickle_folder_name,
                 f'{vessel_id}_force_sync.pickle')
             if full_pickle_path:
-                connector_id, execution_time = load_pickle_variables(
-                    full_pickle_path)
-    elif args.connector_id:
-        connector_id = args.connector_id
-    
-    if not connector_id and not execution_time:
+                ## grab variables from the pickle file only if the connector id from the pickle matches the one provided
+                temp_con_id, temp_execution_time = load_pickle_variables(full_pickle_path)
+                if temp_con_id == connector_id:
+                    execution_time = temp_execution_time
+                # else:
+                #     connector_id, execution_time = load_pickle_variables(
+                #         full_pickle_path)
+    # if args.connector_id:
+    #     connector_id = args.connector_id
+    elif connector_id:
+        full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
+        temp_con_id, temp_execution_time = load_pickle_variables(full_pickle_path)
+        if temp_con_id == connector_id:
+            execution_time = temp_execution_time
+
+    else:
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
         if full_pickle_path:
             connector_id, execution_time = load_pickle_variables(full_pickle_path)
+
+
+    # if shipyard_upstream_vessels:
+    #     shipyard_upstream_vessels = shipyard_upstream_vessels.split(',')
+    #     for vessel_id in shipyard_upstream_vessels:
+    #         full_pickle_path = working_pickle_file(
+    #             pickle_folder_name,
+    #             f'{vessel_id}_force_sync.pickle')
+    #         if full_pickle_path:
+    #             connector_id, execution_time = load_pickle_variables(
+    #                 full_pickle_path)
+    # elif args.connector_id:
+    #     connector_id = args.connector_id
+    
 
     connector_details_response = get_connector_details(
         connector_id,
@@ -156,6 +183,7 @@ def main():
     else:
         print(connector_details_response['message'])
         sys.exit(1)
+
 
 
 if __name__ == '__main__':

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -131,7 +131,7 @@ def main():
     execution_time = None
     ## if there are upstream vessels
     ## if the connector id is not provided then we don't care about the other 
-    if shipyard_upstream_vessels and connector_id:
+    if shipyard_upstream_vessels:
         shipyard_upstream_vessels = shipyard_upstream_vessels.split(',')
         for vessel_id in shipyard_upstream_vessels:
             full_pickle_path = working_pickle_file(
@@ -140,8 +140,11 @@ def main():
             if full_pickle_path:
                 ## grab variables from the pickle file only if the connector id from the pickle matches the one provided
                 temp_con_id, temp_execution_time = load_pickle_variables(full_pickle_path)
-                if temp_con_id == connector_id:
-                    execution_time = temp_execution_time
+                if connector_id:
+                    if temp_con_id == connector_id:
+                        execution_time = temp_execution_time
+                else:
+                    connector_id = temp_con_id 
     ## if just the connector is provided
     elif connector_id:
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -145,7 +145,7 @@ def main():
     ## if just the connector is provided
     elif connector_id:
         full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
-        if os.path.isfile(full_pickle_path):
+        if full_pickle_path:
             temp_con_id, temp_execution_time = load_pickle_variables(full_pickle_path)
             if temp_con_id == connector_id:
                 execution_time = temp_execution_time

--- a/fivetran_blueprints/check_sync_status.py
+++ b/fivetran_blueprints/check_sync_status.py
@@ -127,9 +127,8 @@ def main():
 
     connector_id = None
     execution_time = None
-    if args.connector_id:
-        connector_id = args.connector_id
-    elif shipyard_upstream_vessels:
+    ## check to see if the connector id is available in upstream vessels
+    if shipyard_upstream_vessels:
         shipyard_upstream_vessels = shipyard_upstream_vessels.split(',')
         for vessel_id in shipyard_upstream_vessels:
             full_pickle_path = working_pickle_file(
@@ -138,14 +137,32 @@ def main():
             if full_pickle_path:
                 connector_id, execution_time = load_pickle_variables(
                     full_pickle_path)
-
+    elif args.connector_id:
+        connector_id = args.connector_id
+    
     if not connector_id and not execution_time:
-        full_pickle_path = working_pickle_file(
-            pickle_folder_name,
-            f'force_sync.pickle')
+        full_pickle_path = working_pickle_file(pickle_folder_name,f'force_sync.pickle')
         if full_pickle_path:
-            connector_id, execution_time = load_pickle_variables(
-                full_pickle_path)
+            connector_id, execution_time = load_pickle_variables(full_pickle_path)
+    # if args.connector_id:
+    #     connector_id = args.connector_id
+    # elif shipyard_upstream_vessels:
+    #     shipyard_upstream_vessels = shipyard_upstream_vessels.split(',')
+    #     for vessel_id in shipyard_upstream_vessels:
+    #         full_pickle_path = working_pickle_file(
+    #             pickle_folder_name,
+    #             f'{vessel_id}_force_sync.pickle')
+    #         if full_pickle_path:
+    #             connector_id, execution_time = load_pickle_variables(
+    #                 full_pickle_path)
+
+    # if not connector_id and not execution_time:
+    #     full_pickle_path = working_pickle_file(
+    #         pickle_folder_name,
+    #         f'force_sync.pickle')
+    #     if full_pickle_path:
+    #         connector_id, execution_time = load_pickle_variables(
+    #             full_pickle_path)
 
     connector_details_response = get_connector_details(
         connector_id,


### PR DESCRIPTION
Addressed the issue where the blueprint is grabbing the incorrect execution time when the `connector-id` is provided. This now first grabs the connector-id and execution time from the output of the previous vessel.